### PR TITLE
"The Gift" unlocks spellcasting tab of character sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -608,6 +608,7 @@
 		"attackOptions": "Attack Options",
 		"abilities": "Abilities",
 		"casting": "Casting",
+		"grantsSpells": "Grants Spells",
 		"settings": "Settings",
 		"sneakAttack": "Sneak Attack",
 		"totalSneakDice": "Total Sneak Dice",

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -891,10 +891,12 @@ export default class ActorFC extends Actor {
 
         // Get information from every item on the character that has a castingLevel
         let items = actorData.items.filter(function(item) {return item.system.castingLevel})
+        // Drop weapons and armor that are not equipped
+        items = items.filter(item => ((item.type != "weapon" && item.type != "armour") || item.system.readied || item.system.equipped) )
         if(items.length > 0)
         {
             // Only set the casting level if we don't already have a class that gives us casting levels
-            if((items.filter(function(item) {return item.system.type === 'class'}).length === 0))
+            if(items.filter(function(item) {return item.system.type === 'class'}).length === 0)
             {
                 char.castingLevel = 1;
             }

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -844,19 +844,33 @@ export default class ActorFC extends Actor {
     {
       const char = actorData.system;
       let castingFeats = [];
-      
-      //Go through all feats and add any spellcasting feats to the castingFeats array
+      let grantsSpellcastingItems = 0;
+
+      // Get information from every item on the character
+      for(let [l, i] of Object.entries(this.items || {}))
+      {
+          // add any spellcasting feats to the castingFeats array
+          if (i.type === "feat" && i.system.featType == "fantasycraft.spellcasting")
+              castingFeats.push(i);
+
+          if(i.system.grantsSpellcasting === true)
+              grantsSpellcastingItems++;
+      }
+
+/*      //Go through all feats and add any spellcasting feats to the castingFeats array
       for ( let [l, f] of Object.entries(this.itemTypes.feat || {}) ) 
       {
         if (f.system.featType == "fantasycraft.spellcasting")
           castingFeats.push(f);
-      }
+      }*/
       //Casting feats equals the length of the array we just created
       char.castingFeats = castingFeats.length;
 
       //Characters spellsave equals number of spellcasting feats plus Charisa modifier.
       char.spellSave = 10 + char.abilityScores.charisma.mod + char.castingFeats;
 
+      if(grantsSpellcastingItems > 0)
+          char.isSpellcaster = true;
 
       if (char.isArcane)
       {

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -70,8 +70,10 @@ export default class ActorFC extends Actor {
       this._prepareSaves(actorData);
       this._calculateWounds(actorData);
       this._linkAttacks(actorData);
+      this._prepareCastingFromItems(actorData);
 
-      this._prepareCasting(actorData);
+      if (data.castingLevel > 0)
+        this._prepareCasting(actorData);
 
       this._compileResistances(actorData);
       this._getTrickUses(actorData);
@@ -843,44 +845,18 @@ export default class ActorFC extends Actor {
     {
       const char = actorData.system;
       let castingFeats = [];
-      let grantsSpellcastingItems = 0;
 
-      // Get information from every item on the character
-    let items = actorData.items.filter(function(item) {return true})
-    for (let [key, item] of Object.entries(items))
-      {
-          // add any spellcasting feats to the castingFeats array
-          if (item.type === "feat" && item.system.featType == "fantasycraft.spellcasting")
-              castingFeats.push(item);
-
-          if(item.system.grantsSpellcasting === true)
-          {
-              grantsSpellcastingItems++;
-              console.log(`${grantsSpellcastingItems} spellcasting items`);
-          }
-      }
-
-/*      //Go through all feats and add any spellcasting feats to the castingFeats array
+      //Go through all feats and add any spellcasting feats to the castingFeats array
       for ( let [l, f] of Object.entries(this.itemTypes.feat || {}) ) 
       {
         if (f.system.featType == "fantasycraft.spellcasting")
           castingFeats.push(f);
-      }*/
+      }
       //Casting feats equals the length of the array we just created
       char.castingFeats = castingFeats.length;
 
       //Characters spellsave equals number of spellcasting feats plus Charisa modifier.
       char.spellSave = 10 + char.abilityScores.charisma.mod + char.castingFeats;
-
-      if(grantsSpellcastingItems > 0)
-      {
-          char.isSpellcaster = true;
-      }
-      else
-      {
-         char.isSpellcaster = false;
-      }
-    console.log(`char.isSpellcaster ${char.isSpellcaster}`);
 
       if (char.isArcane)
       {
@@ -907,6 +883,26 @@ export default class ActorFC extends Actor {
         char.arcane.spellPointMax = (this.getFlag("fantasycraft", "Spell Power")) ? classSpellPoints + char.startingActionDice + magicBonus : classSpellPoints + magicBonus
 
       }
+    }
+
+    _prepareCastingFromItems(actorData)
+    {
+        const char = actorData.system;
+
+        // Get information from every item on the character that has a castingLevel
+        let items = actorData.items.filter(function(item) {return item.system.castingLevel})
+        if(items.length > 0)
+        {
+            // Only set the casting level if we don't already have a class that gives us casting levels
+            if((items.filter(function(item) {return item.system.type === 'class'}).length === 0))
+            {
+                char.castingLevel = 1;
+            }
+        }
+        else
+        {
+            char.castingLevel = 0;
+        }
     }
 
     _prepareLifeStyle()

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -70,9 +70,8 @@ export default class ActorFC extends Actor {
       this._prepareSaves(actorData);
       this._calculateWounds(actorData);
       this._linkAttacks(actorData);
-      
-      if (data.castingLevel > 0)
-        this._prepareCasting(actorData);
+
+      this._prepareCasting(actorData);
 
       this._compileResistances(actorData);
       this._getTrickUses(actorData);
@@ -847,14 +846,18 @@ export default class ActorFC extends Actor {
       let grantsSpellcastingItems = 0;
 
       // Get information from every item on the character
-      for(let [l, i] of Object.entries(this.items || {}))
+    let items = actorData.items.filter(function(item) {return true})
+    for (let [key, item] of Object.entries(items))
       {
           // add any spellcasting feats to the castingFeats array
-          if (i.type === "feat" && i.system.featType == "fantasycraft.spellcasting")
-              castingFeats.push(i);
+          if (item.type === "feat" && item.system.featType == "fantasycraft.spellcasting")
+              castingFeats.push(item);
 
-          if(i.system.grantsSpellcasting === true)
+          if(item.system.grantsSpellcasting === true)
+          {
               grantsSpellcastingItems++;
+              console.log(`${grantsSpellcastingItems} spellcasting items`);
+          }
       }
 
 /*      //Go through all feats and add any spellcasting feats to the castingFeats array
@@ -870,7 +873,14 @@ export default class ActorFC extends Actor {
       char.spellSave = 10 + char.abilityScores.charisma.mod + char.castingFeats;
 
       if(grantsSpellcastingItems > 0)
+      {
           char.isSpellcaster = true;
+      }
+      else
+      {
+         char.isSpellcaster = false;
+      }
+    console.log(`char.isSpellcaster ${char.isSpellcaster}`);
 
       if (char.isArcane)
       {

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -51,8 +51,9 @@ export default class ItemFC extends Item {
       this.charms = [data.charms.charm1, data.charms.charm2,
         data.charms.charm3, data.charms.charm4]
       
-      this._calculateMagicItemReputationCost(itemData)
+      this._calculateMagicItemReputationCost(itemData);
 
+      this._calculateCharmCastingLevel(itemData);
 
       for (let i = itemData.system.charms.charmNumber+1; i <= 4; i++)
       {
@@ -179,6 +180,18 @@ export default class ItemFC extends Item {
       totalRepCost -= repDiscount;
 
     itemData.system.totalReputation = totalRepCost;
+  }
+
+  _calculateCharmCastingLevel(itemData)
+  {
+    for (let i = 1; i <= itemData.system.charms.charmNumber; i++)
+    {
+      let charmNum = "charm" + i;
+      let charmInfo = itemData.system.charms[charmNum];
+
+      if (charmInfo.ability == "spellEffect")
+        itemData.system.castingLevel = itemData.system.itemLevel;
+    }
   }
 
   _separateSpellTerms(terms) 

--- a/template.json
+++ b/template.json
@@ -876,7 +876,7 @@
 			},
 			"grants-spellcasting":
 			{
-				"grantsSpellcasting": false
+				"castingLevel": false
 			}
 		},
 		"ancestry":
@@ -1141,7 +1141,6 @@
 			"lifeStyle": [],
 			"legend": [],
 			"spellPoints": [],
-			"castingLevel": false,
 			"abilities": "",
 			"classTable": ""
 		},

--- a/template.json
+++ b/template.json
@@ -234,6 +234,7 @@
 			"spell-casting":
 			{
 				"castingLevel": 0,
+				"isSpellcaster": false,
 				"isArcane": false,
 				"isDivine": false,
 				"spellSave": 0,
@@ -872,11 +873,15 @@
 						"spellLevel": 0
 					}
 				}
+			},
+			"grants-spellcasting":
+			{
+				"grantsSpellcasting": false
 			}
 		},
 		"ancestry":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"isTalent": false,
 			"stats": {
 				"stat1":
@@ -927,7 +932,7 @@
 		},
 		"armour":
 		{
-			"templates": ["object", "description, enchanted"],
+			"templates": ["object", "description, enchanted", "grants-spellcasting"],
 			"armourCoverage": "Partial",
 			"damageReduction": 0,
 			"armourCheckPenalty": 0,
@@ -998,7 +1003,7 @@
 		},
 		"weapon":
 		{
-			"templates": ["object", "description", "enchanted"],
+			"templates": ["object", "description", "enchanted", "grants-spellcasting"],
 			"weaponProficiency": "Edged",
 			"weaponCategory": "axe",
 			"damage": "1d6",
@@ -1048,7 +1053,7 @@
 		},
 		"general":
 		{
-			"templates": ["object", "description", "enchanted"],
+			"templates": ["object", "description", "enchanted", "grants-spellcasting"],
 			"itemType": "good",
 			"availability": 0,
 			"speed": 
@@ -1116,7 +1121,7 @@
  		},
 		"class":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"levels": 1,
 			"vitality": 9,
 			"skillPoints": 6,
@@ -1171,7 +1176,7 @@
 		},
 		"feat":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"featType": "Basic Combat",
 			"flavorText": "",
 			"prerequisites": "",
@@ -1233,7 +1238,7 @@
 		},
 		"path":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"pathStep": 0,
 			"step1":
 			{
@@ -1303,7 +1308,7 @@
 		},
 		"spell":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"school:": "none",
 			"discipline": "none",
 			"level": 0,
@@ -1368,13 +1373,13 @@
 		},
 		"specialty":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"feat": "none",
 			"requirement": "none"
 		},
 		"stance":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"inStance": false,
 			"effect1": 
 			{
@@ -1391,7 +1396,7 @@
 		},
 		"trick":
 		{
-			"templates": ["description"],
+			"templates": ["description", "grants-spellcasting"],
 			"effect": 
 			{
 				"rollModifier": 0,

--- a/templates/items/parts/details.handlebars
+++ b/templates/items/parts/details.handlebars
@@ -159,9 +159,9 @@
         {{/if}}
     </div>
     <div class="form-group item-customization-section">
-        {{!-- Item grants casting --}}
-        {{localize "fantasycraft.casting"}}:
-        <input type="checkbox" name="system.castingLevel" {{checked item.system.castingLevel}}/>
+        {{!-- Item grants spells --}}
+        <label>{{localize "fantasycraft.grantsSpells"}}: </label>
+        <input type="checkbox" name="system.castingLevel" data-dtype="Boolean" {{checked item.system.castingLevel}}/>
     </div>
     {{!-- If the checkbox is checked set a flag based on the name of the feat --}}
     <div class="form-group item-customization-section">

--- a/templates/items/parts/details.handlebars
+++ b/templates/items/parts/details.handlebars
@@ -158,6 +158,10 @@
         <input class="mediumField" type="number" name="system.resistances.value2" value="{{item.system.resistances.value2}}" />
         {{/if}}
     </div>
+    <div class="form-group item-customization-section">
+        <label>{{localize "fantasycraft.grantsSpellcasting"}}</label>
+        <input type="checkbox" name="system.grantsSpellcasting" data-dtype="Boolean" {{checked item.system.grantsSpellcasting}} />
+    </div>
     {{!-- If the checkbox is checked set a flag based on the name of the feat --}}
     <div class="form-group item-customization-section">
         <label>{{localize "fantasycraft.featIsFlag"}}: </label>

--- a/templates/items/parts/details.handlebars
+++ b/templates/items/parts/details.handlebars
@@ -159,8 +159,9 @@
         {{/if}}
     </div>
     <div class="form-group item-customization-section">
-        <label>{{localize "fantasycraft.grantsSpellcasting"}}</label>
-        <input type="checkbox" name="system.grantsSpellcasting" data-dtype="Boolean" {{checked item.system.grantsSpellcasting}} />
+        {{!-- Item grants casting --}}
+        {{localize "fantasycraft.casting"}}:
+        <input type="checkbox" name="system.castingLevel" {{checked item.system.castingLevel}}/>
     </div>
     {{!-- If the checkbox is checked set a flag based on the name of the feat --}}
     <div class="form-group item-customization-section">

--- a/templates/sheets/character-sheet.handlebars
+++ b/templates/sheets/character-sheet.handlebars
@@ -374,7 +374,7 @@
         <div class="tab attributes flexcol" data-group="primary" data-tab="items-and-reputation">
             {{> "systems/fantasycraft/templates/sheets/pages/items-and-reputation.handlebars"}}
         </div>
-        {{#if actor.system.isSpellcaster}}
+        {{#if actor.system.castingLevel}}
         <div class="tab attributes flexcol" data-group="primary" data-tab="spellcasting">
             {{> "systems/fantasycraft/templates/sheets/pages/spellcasting.handlebars"}}
         </div>

--- a/templates/sheets/character-sheet.handlebars
+++ b/templates/sheets/character-sheet.handlebars
@@ -374,7 +374,7 @@
         <div class="tab attributes flexcol" data-group="primary" data-tab="items-and-reputation">
             {{> "systems/fantasycraft/templates/sheets/pages/items-and-reputation.handlebars"}}
         </div>
-        {{#if actor.system.castingLevel}}
+        {{#if actor.system.isSpellcaster}}
         <div class="tab attributes flexcol" data-group="primary" data-tab="spellcasting">
             {{> "systems/fantasycraft/templates/sheets/pages/spellcasting.handlebars"}}
         </div>

--- a/templates/sheets/pages/combat-page.handlebars
+++ b/templates/sheets/pages/combat-page.handlebars
@@ -181,7 +181,7 @@
     <ul class="flexrow attributes">
         <li>
             <h4 class="category-label"> {{localize "fantasycraft.armour"}} </h4>
-            <section class="armour-list flexcol">
+            <section class="armour-list flexcol item-list">
                 {{#each armour as |armour id|}}
                 <div class="item ownedItem item-card flexrow" data-item-id="{{_id}}" data-item-name="{{armour.name}}">
                     <span class="flex6">{{armour.name}}, {{localize "fantasycraft.dr"}}: {{armour.system.damageReduction}}, {{localize "fantasycraft.acp"}}: {{armour.system.armourCheckPenalty}} {{localize "fantasycraft.dp"}}: {{armour.system.defensePenalty}}</span>

--- a/templates/sheets/pages/items-and-reputation.handlebars
+++ b/templates/sheets/pages/items-and-reputation.handlebars
@@ -106,7 +106,7 @@
                 </a>
             </h3>
             <div class="category-body" style="padding: 0px">
-                <section class="two-column">
+                <section class="two-column item-list">
                 {{#each ownedItems as |item id|}}
                     {{> "systems/fantasycraft/templates/partials/item-part.hbs" item id=_id inSheet=true}}
                 {{/each}}


### PR DESCRIPTION
"The Gift" gives a character spells, albeit ones they can cast without fail.  Still, they should have access to the spellcasting tab of the character sheet so they can see what spells they have.

Moves the "castingLevel" attribute of "class" type items to a template that all items types now inherit, so any item that grants spells (such as the Gift) reveals the spellcasting tab. Adds a checkbox to the "details" subsheet to mark a item as granting spells.

Only applies the casting level of 1 if the character does not have a class that grants spellcasting.

Items in the Compendia -- particularly The Gift --will need to be updated to have their castingLevel set to `true` in order to take advantage of this functionality.